### PR TITLE
Feature/logging improvements

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -1,3 +1,4 @@
 appraise 'rails-5.0' do
   gem 'rails', '5.0.0'
+  gem 'tzinfo-data'
 end

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM ruby:2.5.1-alpine
+MAINTAINER wyatt@apsis.io
+
+RUN apk add --no-cache --update \
+    bash \
+    alpine-sdk \
+    sqlite-dev
+
+ENV APP_HOME /app
+WORKDIR $APP_HOME
+
+COPY . $APP_HOME/
+
+EXPOSE 3000
+
+CMD ["bash"]

--- a/README.md
+++ b/README.md
@@ -52,7 +52,6 @@ To install this gem onto your local machine, run `bundle exec rake install`. To 
 
 * `docker-compose up`
 * `bin/ssh_to_container`
-* `bin/setup`
 
 ## Testing
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,17 @@ class PatientInfo < ActiveRecord::Base
 end
 ```
 
+Access is granted on a model level:
+```ruby
+info = new PatientInfo
+info.allow_phi!("allowed_user@example.com", "Customer Service")
+```
+
+or a class:
+```ruby
+PatientInfo.allow_phi!("allowed_user@example.com", "Customer Service")
+```
+
 ## Development
 
 After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.

--- a/README.md
+++ b/README.md
@@ -37,6 +37,12 @@ After checking out the repo, run `bin/setup` to install dependencies. Then, run 
 
 To install this gem onto your local machine, run `bundle exec rake install`. To release a new version, update the version number in `version.rb`, and then run `bundle exec rake release`, which will create a git tag for the version, push git commits and tags, and push the `.gem` file to [rubygems.org](https://rubygems.org).
 
+### Docker
+
+* `docker-compose up`
+* `bin/ssh_to_container`
+* `bin/setup`
+
 ## Testing
 
     $ bundle exec appraisal rspec spec/phi_attrs_spec.rb

--- a/bin/setup
+++ b/bin/setup
@@ -3,5 +3,5 @@ set -euo pipefail
 IFS=$'\n\t'
 set -vx
 
-bundle install
+bundle check || bundle install
 bundle exec appraisal install

--- a/bin/ssh_to_container
+++ b/bin/ssh_to_container
@@ -1,0 +1,3 @@
+#! /bin/bash
+
+docker-compose run rails sh

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,13 @@ services:
     volumes:
       - bundle_cache:/bundle
       - .:/app
-    command: tail -f /etc/hosts
+    environment:
+      - BUNDLE_JOBS=5
+      - BUNDLE_PATH=/bundle
+      - BUNDLE_BIN=/bundle/bin
+      - GEM_HOME=/bundle
+    command:
+      - docker/start.sh
 
 volumes:
   bundle_cache:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     volumes:
       - bundle_cache:/bundle
       - .:/app
-    command: docker/start.sh
+    command: tail -f /etc/hosts
 
 volumes:
   bundle_cache:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,12 @@
+version: '3'
+
+services:
+  rails:
+    build: .
+    volumes:
+      - bundle_cache:/bundle
+      - .:/app
+    command: docker/start.sh
+
+volumes:
+  bundle_cache:

--- a/docker/start.sh
+++ b/docker/start.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+echo "Beginning Setup"
+/app/bin/setup
+
+echo "Environment Ready"
+tail -f /etc/hosts

--- a/docker/start.sh
+++ b/docker/start.sh
@@ -1,9 +1,0 @@
- /bin/bash
-
-# Run Setup
-/app/bin/setup
-
-# Run Console
-/app/bin/console
-
-tail -f /etc/hosts

--- a/docker/start.sh
+++ b/docker/start.sh
@@ -1,0 +1,9 @@
+ /bin/bash
+
+# Run Setup
+/app/bin/setup
+
+# Run Console
+/app/bin/console
+
+tail -f /etc/hosts

--- a/gemfiles/rails_5.0.gemfile
+++ b/gemfiles/rails_5.0.gemfile
@@ -3,5 +3,6 @@
 source "https://rubygems.org"
 
 gem "rails", "5.0.0"
+gem "tzinfo-data"
 
 gemspec path: "../"

--- a/lib/phi_attrs.rb
+++ b/lib/phi_attrs.rb
@@ -5,6 +5,7 @@ require 'request_store'
 require 'phi_attrs/version'
 require 'phi_attrs/configure'
 require 'phi_attrs/railtie' if defined?(Rails)
+require 'phi_attrs/formatter'
 require 'phi_attrs/logger'
 require 'phi_attrs/exceptions'
 require 'phi_attrs/phi_record'
@@ -12,8 +13,10 @@ require 'phi_attrs/phi_record'
 module PhiAttrs
   def phi_model(with: nil, except: nil)
     include PhiRecord
+    logger = ActiveSupport::Logger.new(PhiAttrs.log_path)
+    logger.formatter = Formatter.new
+    file_logger = ActiveSupport::TaggedLogging.new(logger)
 
-    file_logger = ActiveSupport::TaggedLogging.new(ActiveSupport::Logger.new(PhiAttrs.log_path))
     PhiAttrs::Logger.logger = file_logger
   end
 
@@ -31,5 +34,3 @@ module PhiAttrs
     @@log_path = value
   end
 end
-
-

--- a/lib/phi_attrs/formatter.rb
+++ b/lib/phi_attrs/formatter.rb
@@ -1,0 +1,10 @@
+module PhiAttrs
+  Format = "%s %5s: %s\n".freeze
+
+  # https://github.com/ruby/ruby/blob/trunk/lib/logger.rb#L587
+  class Formatter < ::Logger::Formatter
+    def call(severity, timestamp, progname, msg)
+      Format % [format_datetime(timestamp), severity, msg2str(msg)]
+    end
+  end
+end

--- a/lib/phi_attrs/phi_record.rb
+++ b/lib/phi_attrs/phi_record.rb
@@ -29,13 +29,16 @@ module PhiAttrs
           user_id: user_id,
           reason: reason
         }
-
-        PhiAttrs::Logger.info("PHI Access Enabled for #{user_id}: #{reason}")
+        PhiAttrs::Logger.tagged(PHI_ACCESS_LOG_TAG, name) do
+          PhiAttrs::Logger.info("PHI Access Enabled for #{user_id}: #{reason}")
+        end
       end
 
       def disallow_phi!
         RequestStore.store[:phi_access].delete(name) if RequestStore.store[:phi_access].present?
-        PhiAttrs::Logger.info('PHI access disabled')
+        PhiAttrs::Logger.tagged(PHI_ACCESS_LOG_TAG, name) do
+          PhiAttrs::Logger.info('PHI access disabled')
+        end
       end
     end
 
@@ -46,8 +49,8 @@ module PhiAttrs
       @__phi_access_allowed = false
       @__phi_access_logged = false
 
-      @__phi_log_id = persisted? ? attributes[self.class.primary_key] : object_id
-      @__phi_log_key = "#{PHI_ACCESS_LOG_TAG} #{@__phi_log_id}"
+      @__phi_log_id = persisted? ? attributes[self.class.primary_key] : "o##{object_id}"
+      @__phi_log_keys = [PHI_ACCESS_LOG_TAG, self.class, @__phi_log_id]
 
       # Wrap attributes with PHI Logger and Access Control
       __phi_wrapped_methods.each { |attr| phi_wrap_method(attr) }
@@ -58,7 +61,7 @@ module PhiAttrs
     end
 
     def allow_phi!(user_id, reason)
-      PhiAttrs::Logger.tagged(@__phi_log_key) do
+      PhiAttrs::Logger.tagged( *@__phi_log_keys ) do
         @__phi_access_allowed = true
         @__phi_user_id = user_id
         @__phi_access_reason = reason
@@ -68,7 +71,7 @@ module PhiAttrs
     end
 
     def disallow_phi!
-      PhiAttrs::Logger.tagged(@__phi_log_key) do
+      PhiAttrs::Logger.tagged(*@__phi_log_keys) do
         @__phi_access_allowed = false
         @__phi_user_id = nil
         @__phi_access_reason = nil
@@ -98,11 +101,11 @@ module PhiAttrs
       unwrapped_method = :"__#{method_name}_phi_unwrapped"
 
       self.class.send(:define_method, wrapped_method) do |*args, &block|
-        PhiAttrs::Logger.tagged(@__phi_log_key) do
-          raise PhiAttrs::Exceptions::PhiAccessException, "Attempted PHI acces for #{self.class.name} #{@__phi_user_id}" unless phi_allowed?
+        PhiAttrs::Logger.tagged(*@__phi_log_keys) do
+          raise PhiAttrs::Exceptions::PhiAccessException, "Attempted PHI access for #{self.class.name} #{@__phi_user_id}" unless phi_allowed?
 
           unless @__phi_access_logged
-            PhiAttrs::Logger.info("#{@__phi_user_id} accessing #{self.class.name} #{@__phi_user_id}.\n\t access logging triggered by method: #{method_name}")
+            PhiAttrs::Logger.info("#{@__phi_user_id} accessing #{self.class.name} allowed by #{phi_allowed_by}.\n\t access logging triggered by method: #{method_name}")
             @__phi_access_logged = true
           end
 
@@ -111,7 +114,7 @@ module PhiAttrs
       end
 
       # method_name => wrapped_method => unwrapped_method
-      self.class.send(:alias_method, unwrapped_method, method_name) 
+      self.class.send(:alias_method, unwrapped_method, method_name)
       self.class.send(:alias_method, method_name, wrapped_method)
 
       self.class.__phi_methods_wrapped << method_name

--- a/spec/phi_attrs_spec.rb
+++ b/spec/phi_attrs_spec.rb
@@ -42,13 +42,44 @@ RSpec.describe PhiAttrs do
     end
 
     it 'should log when granting phi to class' do
+      patient_john # TODO Clean up: Logger.logger isn't defined unless we load something tagged with phi_attrs
       expect(PhiAttrs::Logger.logger).to receive(:info)
       PatientInfo.allow_phi! 'test', 'unit tests'
     end
 
     it 'should log when revokes phi to class' do
+      patient_john # TODO Clean up: Logger.logger isn't defined unless we load something tagged with phi_attrs
       expect(PhiAttrs::Logger.logger).to receive(:info)
       PatientInfo.disallow_phi!
+    end
+
+    it 'should log when accessing method' do
+      PatientInfo.allow_phi! 'test', 'unit tests'
+      expect(PhiAttrs::Logger.logger).to receive(:info)
+      patient_jane.first_name
+    end
+
+    it 'should log once when accessing multiple methods' do
+      PatientInfo.allow_phi! 'test', 'unit tests'
+      expect(PhiAttrs::Logger.logger).to receive(:info)
+      patient_jane.first_name
+      patient_jane.birthday
+    end
+
+    it 'should log object_id for unpersisted' do
+      PatientInfo.allow_phi! 'test', 'unit tests'
+      expect(PhiAttrs::Logger.logger).to receive(:tagged).with(PhiAttrs::PHI_ACCESS_LOG_TAG, PatientInfo.name, "Object: #{patient_jane.object_id}").and_call_original
+      expect(PhiAttrs::Logger.logger).to receive(:info)
+      patient_jane.first_name
+    end
+
+    it 'should log id for persisted' do
+      PatientInfo.allow_phi! 'test', 'unit tests'
+      patient_jane.save
+      expect(patient_jane.persisted?).to be true
+      expect(PhiAttrs::Logger.logger).to receive(:tagged).with(PhiAttrs::PHI_ACCESS_LOG_TAG, PatientInfo.name, "Key: #{patient_jane.id}").and_call_original
+      expect(PhiAttrs::Logger.logger).to receive(:info).and_call_original
+      patient_jane.first_name
     end
   end
 

--- a/spec/phi_attrs_spec.rb
+++ b/spec/phi_attrs_spec.rb
@@ -23,6 +23,7 @@ RSpec.describe PhiAttrs do
 
   context 'logging' do
     it 'should log an error when raising an exception' do
+      patient_john # TODO Clean up: Logger.logger isn't defined unless we load something tagged with phi_attrs
       expect(PhiAttrs::Logger.logger).to receive(:error).with('my error message')
 
       expect {
@@ -33,6 +34,21 @@ RSpec.describe PhiAttrs do
     it 'should log an error for unauthorized access' do
       expect(PhiAttrs::Logger.logger).to receive(:error)
       expect { patient_john.birthday }.to raise_error(PhiAttrs::Exceptions::PhiAccessException)
+    end
+
+    it 'should log when granting phi to instance' do
+      expect(PhiAttrs::Logger.logger).to receive(:info)
+      patient_jane.allow_phi! 'test', 'unit tests'
+    end
+
+    it 'should log when granting phi to class' do
+      expect(PhiAttrs::Logger.logger).to receive(:info)
+      PatientInfo.allow_phi! 'test', 'unit tests'
+    end
+
+    it 'should log when revokes phi to class' do
+      expect(PhiAttrs::Logger.logger).to receive(:info)
+      PatientInfo.disallow_phi!
     end
   end
 


### PR DESCRIPTION
* Adds Docker for no local development
* Adds Timestamp, severity level, class tags, 
* Separate and fix object id / primary key
* Adding some quotes / cleanup for messages & unit tests

Sample logs:
```
2018-06-15T20:31:50.092701   INFO: [PHI Access Log] [PatientInfo] PHI Access Enabled for test: unit tests
2018-06-15T20:31:50.099439   INFO: [PHI Access Log] [PatientInfo] [Key: 1] 'test' accessing PatientInfo.
         access logging triggered by method: first_name


2018-06-15T20:31:50.105567   INFO: [PHI Access Log] [PatientInfo] [Object: 46947763920720] PHI Access Enabled for 'test': unit tests
2018-06-15T20:31:50.105755   INFO: [PHI Access Log] [PatientInfo] [Object: 46947763920720] 'test' accessing PatientInfo.
         access logging triggered by method: first_name


2018-06-15T20:31:50.107080  ERROR: [PHI Access Log] [PatientInfo] [Object: 46947754534440] [UNAUTHORIZED ACCESS] Attempted PHI access for PatientInfo
```
