### PR TITLE
Feature/block level disallow phi

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,6 +267,27 @@ patient.disallow_phi!
 
 * *If access is granted at both class and instance level you will need to call `disallow_phi!` twice, once for the instance and once for the class.*
 
+There is also a block syntax of `disallow_phi` for temporary suppression phi access to the class or instance level
+
+```ruby
+patient = PatientInfo.find(params[:id])
+patient.allow_phi!('allowed_user@example.com', 'Display Patient Data')
+patient.diallow_phi do
+  @data = patient.to_json # PHIAccessException
+end # Access is allowed again beyond this point
+```
+
+or a block level on a class:
+
+```ruby
+PatientInfo.allow_phi!('allowed_user@example.com', 'Display Patient Data')
+PatientInfo.diallow_phi do
+  @data = PatientInfo.find(params[:id]).to_json # PHIAccessException
+end # Access is allowed again beyond this point
+```
+
+* *Reminder instance level `phi_allow` will take precedent over a class level `disallow_phi`*
+
 ### Manual PHI Access Logging
 
 If you aren't using `phi_record` you can still use `phi_attrs` to manually log phi access in your application. Where ever you are granting PHI access call:

--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ patient.allow_phi!('user@example.com', 'reason')
 patient.phi_allowed? # => true
 ```
 
-This also works if access was granted at the class level
+This also works if access was granted at the class level:
 
 ```ruby
 patient = Patient.new
@@ -226,7 +226,28 @@ Patient.allow_phi!('user@example.com', 'reason')
 patient.phi_allowed? # => true
 ```
 
-There is currently no class level equivalent for `phi_allowed?`.
+There is also a `phi_allowed?` check available to see at the class level.
+
+```ruby
+Patient.phi_allowed? # => false
+Patient.allow_phi!('user@example.com', 'reason')
+Patient.phi_allowed? # => true
+```
+
+**Note that any instance level access grants will not change class level access:**
+
+```ruby
+patient = Patient.new
+
+patient.phi_allowed? # => false
+Patient.phi_allowed? # => false
+
+patient.allow_phi!('user@example.com', 'reason')
+
+patient.phi_allowed? # => true
+Patient.phi_allowed? # => false
+```
+
 
 ### Revoking PHI Access
 

--- a/lib/phi_attrs/phi_record.rb
+++ b/lib/phi_attrs/phi_record.rb
@@ -332,7 +332,7 @@ module PhiAttrs
 
       yield if block_given?
 
-      remove_disallow_flag_revoke_extended_phi!
+      remove_disallow_flag_from_extended_phi!
       remove_disallow_flag!
     end
 
@@ -583,7 +583,7 @@ module PhiAttrs
     end
 
     # Adds a disallow PHI access to the stack for all for all `extend`ed relations (or only those given)
-    def remove_disallow_flag_revoke_extended_phi!(relations = nil)
+    def remove_disallow_flag_from_extended_phi!(relations = nil)
       relations ||= @__phi_relations_extended
       relations.each do |relation|
         relation.remove_disallow_flag! if relation.present? && relation_klass(relation).included_modules.include?(PhiRecord)

--- a/lib/phi_attrs/phi_record.rb
+++ b/lib/phi_attrs/phi_record.rb
@@ -202,6 +202,17 @@ module PhiAttrs
         end
       end
 
+      # Whether PHI access is allowed for this class
+      #
+      # @example
+      #   Foo.phi_allowed?
+      #
+      # @return [Boolean] whether PHI access is allowed for this instance
+      #
+      def phi_allowed?
+        __phi_stack.present? && __phi_stack[-1][:phi_access_allowed]
+      end
+
       def __phi_stack
         RequestStore.store[:phi_access] ||= {}
         RequestStore.store[:phi_access][name] ||= []

--- a/spec/phi_attrs/phi_record/class__disallow_phi_spec.rb
+++ b/spec/phi_attrs/phi_record/class__disallow_phi_spec.rb
@@ -3,11 +3,48 @@
 RSpec.describe 'class disallow_phi' do
   file_name = __FILE__
 
-  # TODO: Block syntax when implemented
+  let(:patient_jane) { build(:patient_info, first_name: 'Jane') }
+  let(:patient_john) { build(:patient_info, first_name: 'John') }
+
+  context 'block' do
+    it 'disables all allowances within the block' do |t|
+      PatientInfo.allow_phi!(file_name, t.full_description)
+      expect { patient_jane.first_name }.not_to raise_error
+
+      PatientInfo.disallow_phi do
+        expect { patient_jane.first_name }.to raise_error(access_error)
+      end
+    end
+
+    it 'returns permission after the block' do |t|
+      PatientInfo.allow_phi!(file_name, t.full_description)
+      expect { patient_jane.first_name }.not_to raise_error
+
+      PatientInfo.disallow_phi do
+        expect { patient_jane.first_name }.to raise_error(access_error)
+      end
+
+      expect { patient_jane.first_name }.not_to raise_error
+    end
+
+    it 'does not affect explicit instance allow' do |t|
+      PatientInfo.allow_phi!(file_name, t.full_description)
+      patient_john.allow_phi!(file_name, t.full_description)
+
+      expect { patient_jane.first_name }.not_to raise_error
+      expect { patient_john.first_name }.not_to raise_error
+
+      PatientInfo.disallow_phi do
+        expect { patient_jane.first_name }.to raise_error(access_error)
+        expect { patient_john.first_name }.not_to raise_error
+      end
+
+      expect { patient_jane.first_name }.not_to raise_error
+      expect { patient_john.first_name }.not_to raise_error
+    end
+  end
 
   context 'disallow_phi!' do
-    let(:patient_jane) { build(:patient_info, first_name: 'Jane') }
-
     it 'disallows whole stack' do |t|
       PatientInfo.allow_phi!(file_name + '1', t.full_description)
       expect { patient_jane.first_name }.not_to raise_error

--- a/spec/phi_attrs/phi_record/class__phi_allowed_spec.rb
+++ b/spec/phi_attrs/phi_record/class__phi_allowed_spec.rb
@@ -1,10 +1,72 @@
 # frozen_string_literal: true
 
 RSpec.describe 'class phi_allowed?' do
-  # file_name = __FILE__
-  # let(:patient_jane) { build(:patient_info, first_name: 'Jane') }
-  # let(:patient_detail) { build(:patient_detail) }
-  # let(:patient_with_detail) { build(:patient_info, first_name: 'Jack', patient_detail: patient_detail) }
+  file_name = __FILE__
+  let(:patient_jane) { build(:patient_info, first_name: 'Jane') }
 
-  # TODO: Not implemented yet
+  context 'authorized' do
+    it 'allows access to any instance' do |t|
+      expect(PatientInfo.phi_allowed?).to be false
+      PatientInfo.allow_phi(file_name, t.full_description) do
+        expect(PatientInfo.phi_allowed?).to be true
+      end
+
+      PatientInfo.allow_phi!(file_name, t.full_description)
+      expect(PatientInfo.phi_allowed?).to be true
+    end
+
+    it 'only allows access to the authorized class' do |t|
+      expect(PatientDetail.phi_allowed?).to be false
+
+      PatientInfo.allow_phi(file_name, t.full_description) do
+        expect(PatientInfo.phi_allowed?).to be true
+        expect(PatientDetail.phi_allowed?).to be false
+      end
+
+      expect(PatientDetail.phi_allowed?).to be false
+      expect(PatientInfo.phi_allowed?).to be false
+
+      PatientInfo.allow_phi!(file_name, t.full_description)
+
+      expect(PatientInfo.phi_allowed?).to be true
+      expect(PatientDetail.phi_allowed?).to be false
+    end
+
+    it 'revokes access after calling disallow_phi!' do |t|
+      expect(PatientInfo.phi_allowed?).to be false
+
+      PatientInfo.allow_phi!(file_name, t.full_description)
+
+      expect(PatientInfo.phi_allowed?).to be true
+
+      PatientInfo.disallow_phi!
+
+      expect(PatientInfo.phi_allowed?).to be false
+    end
+  end
+
+  context 'nested allowances' do
+    it 'retains outer access when disallowed at inner level' do |t|
+      PatientInfo.allow_phi(file_name, t.full_description) do
+        expect(PatientInfo.phi_allowed?).to be true
+
+        PatientInfo.allow_phi(file_name, t.full_description) do
+          expect(PatientInfo.phi_allowed?).to be true
+        end # Inner permission revoked
+
+        expect(PatientInfo.phi_allowed?).to be true
+      end # Outer permission revoked
+
+      expect(PatientInfo.phi_allowed?).to be false
+    end
+  end
+
+  context 'with instance allow_phi' do
+    it 'does not change status' do |t|
+      expect(PatientInfo.phi_allowed?).to be false
+      patient_jane.allow_phi(file_name, t.full_description) do
+        expect(PatientInfo.phi_allowed?).to be false
+      end
+    end
+  end
 end

--- a/spec/phi_attrs/phi_record/instance__disallow_phi_spec.rb
+++ b/spec/phi_attrs/phi_record/instance__disallow_phi_spec.rb
@@ -3,15 +3,16 @@
 RSpec.describe 'instance disallow_phi' do
   file_name = __FILE__
 
+  let(:patient_jane) { build(:patient_info, first_name: 'Jane') }
   let(:patient_john) { build(:patient_info, first_name: 'John') }
 
-  context 'block', skip: 'Not yet implemented' do
+  context 'block' do
     it 'disables all allowances within the block' do |t|
       patient_john.allow_phi!(file_name, t.full_description)
       expect { patient_john.first_name }.not_to raise_error
 
       patient_john.disallow_phi do
-        expect { patient_john.last_name }.to raise_error(access_error)
+        expect { patient_john.first_name }.to raise_error(access_error)
       end
     end
 
@@ -24,6 +25,21 @@ RSpec.describe 'instance disallow_phi' do
       end
 
       expect { patient_john.first_name }.not_to raise_error
+    end
+
+    it 'allows other patient access' do |t|
+      patient_john.allow_phi!(file_name, t.full_description)
+      patient_jane.allow_phi!(file_name, t.full_description)
+      expect { patient_john.first_name }.not_to raise_error
+      expect { patient_jane.first_name }.not_to raise_error
+
+      patient_john.disallow_phi do
+        expect { patient_john.first_name }.to raise_error(access_error)
+        expect { patient_jane.first_name }.not_to raise_error
+      end
+
+      expect { patient_john.first_name }.not_to raise_error
+      expect { patient_jane.first_name }.not_to raise_error
     end
   end
 


### PR DESCRIPTION
This adds block level disallow_phi to class and instance.  

Disallow is a temporary suppression, and like allow mixing the `block syntax` and `! syntax` it is not recommend.

Implements:
https://github.com/apsislabs/phi_attrs/issues/18


This PR is based on the `phi_allowed?` branch to minimize conflicts.
https://github.com/apsislabs/phi_attrs/pull/31