### PR TITLE
Feature/default user

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,36 +300,6 @@ message = 'accessed list of all patients'
 PhiAttrs.log_phi_access(user, message)
 ```
 
-### Default User
-
-Passing around the current user can clutter your code. PHI Attrs allows you to
-configure a controller method that will be called to get the currently logged in
-user:
-
-#### `config/initializers/phi_attrs.rb`
-
-```ruby
-PhiAttrs.configure do |conf|
-  conf.current_user_method = :user_email
-end
-```
-
-#### `app/controllers/home_controller.rb`
-
-```ruby
-class ApplicationController < ActionController::Base
-  private
-
-  def user_email
-    current_user&.email
-  end
-end
-```
-
-With the above code, any call to `allow_phi` (that starts in a controller
-derived from ApplicationController) will use the result of `user_email` as the
-user argument of `allow_phi`.
-
 ### Reason Translations
 
 It can get cumbersome to pass around PHI Access reasons. PHI Attrs allows you to
@@ -372,6 +342,45 @@ If you have a typo in your en.yml file or you choose not to provide a translatio
 for your phi reasons your code will fail with an ArgumentError. To assist you in
 debugging PHI Attrs will print a `:warn` message with the expected location for
 the missing translation.
+
+### Default User
+
+Passing around the current user can clutter your code. PHI Attrs allows you to
+configure a controller method that will be called to get the currently logged in
+user:
+
+#### `config/initializers/phi_attrs.rb`
+
+```ruby
+PhiAttrs.configure do |conf|
+  conf.current_user_method = :user_email
+end
+```
+
+#### `app/controllers/home_controller.rb`
+
+```ruby
+class ApplicationController < ActionController::Base
+  private
+
+  def user_email
+    current_user&.email
+  end
+end
+```
+
+With the above code, any call to `allow_phi` (that starts in a controller
+derived from ApplicationController) will use the result of `user_email` as the
+user argument of `allow_phi`.
+
+Note that if you have a default user, but choose not to use translations for
+reasons you'll have to pass `nil` as the user:
+
+```ruby
+person_phi.allow_phi(nil, "Because I felt like looking at PHI") do
+  # Allows PHI
+end
+```
 
 ## Best Practices
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,9 @@ Or install it yourself as:
 
 ## Initialize
 
-Create an initializer to configure the PHI log file location. Example:
+Create an initializer to configure the PHI log file location.
+
+Example:
 
  `config/initializers/phi_attrs.rb`
 
@@ -297,6 +299,36 @@ user = 'user@example.com'
 message = 'accessed list of all patients'
 PhiAttrs.log_phi_access(user, message)
 ```
+
+### Default User
+
+Passing around the current user can clutter your code. PHI Attrs allows you to
+configure a controller method that will be called to get the currently logged in
+user:
+
+#### `config/initializers/phi_attrs.rb`
+
+```ruby
+PhiAttrs.configure do |conf|
+  conf.current_user_method = :user_email
+end
+```
+
+#### `app/controllers/home_controller.rb`
+
+```ruby
+class ApplicationController < ActionController::Base
+  private
+
+  def user_email
+    current_user&.email
+  end
+end
+```
+
+With the above code, any call to `allow_phi` (that starts in a controller
+derived from ApplicationController) will use the result of `user_email` as the
+user argument of `allow_phi`.
 
 ### Reason Translations
 

--- a/lib/phi_attrs.rb
+++ b/lib/phi_attrs.rb
@@ -60,7 +60,11 @@ module PhiAttrs
     def record_i18n_data
       RequestStore.store[:phi_attrs_controller] = self.class.name
       RequestStore.store[:phi_attrs_action] = params[:action]
-      RequestStore.store[:phi_attrs_current_user] = try(PhiAttrs.current_user_method) unless PhiAttrs.current_user_method.nil?
+
+      return if PhiAttrs.current_user_method.nil?
+      return unless respond_to?(PhiAttrs.current_user_method, true)
+
+      RequestStore.store[:phi_attrs_current_user] = send(PhiAttrs.current_user_method)
     end
   end
 end

--- a/lib/phi_attrs.rb
+++ b/lib/phi_attrs.rb
@@ -14,6 +14,7 @@ require 'phi_attrs/phi_record'
 
 module PhiAttrs
   @@log_path = nil
+  @@current_user_method = nil
 
   def self.configure
     yield self if block_given?
@@ -25,6 +26,14 @@ module PhiAttrs
 
   def self.log_path=(value)
     @@log_path = value
+  end
+
+  def self.current_user_method
+    @@current_user_method
+  end
+
+  def self.current_user_method=(value)
+    @@current_user_method = value
   end
 
   def self.log_phi_access(user, message)
@@ -51,6 +60,7 @@ module PhiAttrs
     def record_i18n_data
       RequestStore.store[:phi_attrs_controller] = self.class.name
       RequestStore.store[:phi_attrs_action] = params[:action]
+      RequestStore.store[:phi_attrs_current_user] = try(PhiAttrs.current_user_method) unless PhiAttrs.current_user_method.nil?
     end
   end
 end

--- a/lib/phi_attrs/phi_record.rb
+++ b/lib/phi_attrs/phi_record.rb
@@ -72,7 +72,8 @@ module PhiAttrs
       # @example
       #   Foo.allow_phi!('user@example.com', 'viewing patient record')
       #
-      def allow_phi!(user_id, reason = nil)
+      def allow_phi!(user_id = nil, reason = nil)
+        user_id ||= current_user
         reason ||= i18n_reason
         raise ArgumentError, 'user_id and reason cannot be blank' if user_id.blank? || reason.blank?
 
@@ -106,7 +107,7 @@ module PhiAttrs
       #   end
       #   # PHI Access Disallowed
       #
-      def allow_phi(user_id, reason = nil, allow_only: nil)
+      def allow_phi(user_id = nil, reason = nil, allow_only: nil)
         if allow_only.present?
           raise ArgumentError, 'allow_only must be iterable with each' unless allow_only.respond_to?(:each)
           raise ArgumentError, "allow_only must all be `#{name}` objects" unless allow_only.all? { |t| t.is_a?(self) }
@@ -227,6 +228,10 @@ module PhiAttrs
         access_list.map { |c| "'#{c[:user_id]}'" }.join(',')
       end
 
+      def current_user
+        RequestStore.store[:phi_attrs_current_user]
+      end
+
       def i18n_reason
         controller = RequestStore.store[:phi_attrs_controller]
         action = RequestStore.store[:phi_attrs_action]
@@ -286,7 +291,8 @@ module PhiAttrs
     #   foo = Foo.find(1)
     #   foo.allow_phi!('user@example.com', 'viewing patient record')
     #
-    def allow_phi!(user_id, reason = nil)
+    def allow_phi!(user_id = nil, reason = nil)
+      user_id ||= self.class.current_user
       reason ||= self.class.i18n_reason
       raise ArgumentError, 'user_id and reason cannot be blank' if user_id.blank? || reason.blank?
 
@@ -315,7 +321,7 @@ module PhiAttrs
     #   end
     #   # PHI Access Disallowed Here
     #
-    def allow_phi(user_id, reason = nil)
+    def allow_phi(user_id = nil, reason = nil)
       extended_instances = @__phi_relations_extended.clone
       allow_phi!(user_id, reason)
 

--- a/spec/phi_attrs/controllers/current_user_spec.rb
+++ b/spec/phi_attrs/controllers/current_user_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+class SampleController < ActionController::Base; end
+
+RSpec.describe 'default user', type: :controller do
+  controller SampleController do
+    def index
+      PatientInfo.allow_phi do
+        render json: PatientInfo.all.map(&:summary_json)
+      end
+    end
+
+    private
+
+    def phi_user
+      params[:phi_user]
+    end
+  end
+
+  before :context do
+    PhiAttrs.configure { |c| c.current_user_method = :phi_user }
+  end
+
+  after :context do
+    PhiAttrs.configure { |c| c.current_user_method = nil }
+  end
+
+  before :each do
+    create(:patient_info, :all_random, :with_multiple_health_records)
+  end
+
+  context 'with translation' do
+    it 'uses the translation file for a null reason' do
+      message = I18n.t('phi.sample.index.patient_info')
+      allow(PhiAttrs::Logger.logger).to receive(:info)
+
+      get :index, params: { phi_user: 'Madame Pomfrey' }
+
+      expect(PhiAttrs::Logger.logger).to have_received(:info).with(include('Madame Pomfrey')).at_least(:once)
+      expect(PhiAttrs::Logger.logger).to have_received(:info).with(end_with message).at_least(:once)
+    end
+  end
+end


### PR DESCRIPTION
Merge *after* #34 

This piggy backs on the I18n work to add a default current user. It makes the library almost seamless:

`instance.allow_phi!`

or

`instance.allow_phi!(nil, "Becuase I felt like it")`