### PR TITLE
Fixing unit tests for logging and blocks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,6 @@ sudo: false
 language: ruby
 rvm:
   - 2.4.2
-  before_install:
-    - gem update --system
-    - gem install bundler
+before_install:
+  - gem update --system
+  - gem install bundler

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,6 @@ sudo: false
 language: ruby
 rvm:
   - 2.4.2
-before_install: gem install bundler -v 1.16.1
+  before_install:
+    - gem update --system
+    - gem install bundler

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 sudo: false
 language: ruby
+cache: bundler
 rvm:
   - 2.4.2
 before_install:

--- a/phi_attrs.gemspec
+++ b/phi_attrs.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'request_store', '~> 1.4'
 
   spec.add_development_dependency 'appraisal', '~> 2.1'
-  spec.add_development_dependency 'bundler', '~> 1.16'
+  spec.add_development_dependency 'bundler', '~> 2.0'
   spec.add_development_dependency 'byebug'
   spec.add_development_dependency 'chandler'
   spec.add_development_dependency 'combustion', '~> 0.9.1'

--- a/spec/phi_attrs/logger_spec.rb
+++ b/spec/phi_attrs/logger_spec.rb
@@ -154,6 +154,10 @@ RSpec.describe Logger do
           patient_jane.first_name
         end
 
+        def expect_disallow_message(allowed)
+          expect(PhiAttrs::Logger.logger).to receive(:info).with("PHI access disabled for #{allowed}")
+        end
+
         context 'first class' do
           it 'then class' do |t|
             PatientInfo.allow_phi!(first_allow, t.full_description)
@@ -169,15 +173,17 @@ RSpec.describe Logger do
 
           it 'then class block' do |t|
             PatientInfo.allow_phi!(first_allow, t.full_description)
-            PatientInfo.allow_phi!(second_allow, t.full_description) do
+            PatientInfo.allow_phi(second_allow, t.full_description) do
               test_logger
+              expect_disallow_message(second_allow)
             end
           end
 
           it 'then instance block' do |t|
             PatientInfo.allow_phi!(first_allow, t.full_description)
-            patient_jane.allow_phi!(second_allow, t.full_description) do
+            patient_jane.allow_phi(second_allow, t.full_description) do
               test_logger
+              expect_disallow_message(second_allow)
             end
           end
 
@@ -205,15 +211,17 @@ RSpec.describe Logger do
 
           it 'then class block' do |t|
             patient_jane.allow_phi!(first_allow, t.full_description)
-            PatientInfo.allow_phi!(second_allow, t.full_description) do
+            PatientInfo.allow_phi(second_allow, t.full_description) do
               test_logger
+              expect_disallow_message(second_allow)
             end
           end
 
           it 'then instance block' do |t|
             patient_jane.allow_phi!(first_allow, t.full_description)
-            patient_jane.allow_phi!(second_allow, t.full_description) do
+            patient_jane.allow_phi(second_allow, t.full_description) do
               test_logger
+              expect_disallow_message(second_allow)
             end
           end
 


### PR DESCRIPTION
Fix for #41 was not using the block syntax correctly in unit tests and needed to capture the additional log of disallow at end of block.