### PR TITLE
Method Wrapping Exceptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -438,9 +438,8 @@ Tests are written using [RSpec](http://rspec.info/) and are setup to use [Apprai
     $ bundle exec appraisal rspec spec/path/to/spec.rb
 
 To run just a particular rails version:
-    $  bundle exec appraisal rails-5.1 rspec
-    $  bundle exec appraisal rails-5.2 rspec
-    $  bundle exec appraisal rails-6.0 rspec
+    $  bundle exec appraisal rails_6.1 rspec
+    $  bundle exec appraisal rails-7.0 rspec
 
 ### Console
 

--- a/bin/ssh_to_container
+++ b/bin/ssh_to_container
@@ -5,4 +5,4 @@ if [[ -z $CONTAINER ]]; then
   CONTAINER='ruby3'
 fi
 
-docker-compose run $CONTAINER sh
+docker-compose run $CONTAINER bash

--- a/lib/phi_attrs/phi_record.rb
+++ b/lib/phi_attrs/phi_record.rb
@@ -60,12 +60,6 @@ module PhiAttrs
       #
       def extend_phi_access(*methods)
         self.__phi_extend_methods = methods.map(&:to_s)
-        validate_extended_methods_exist
-      end
-
-      def validate_extended_methods_exist
-        undefined_methods = self.__phi_extend_methods.reject{|m| self.class.respond_to?(m)}
-        raise NameError, "Undefined methods in `extend_phi_access`: #{undefined_methods.join(' ')}" if undefined_methods.any?
       end
 
       # Enable PHI access for any instance of this class.
@@ -669,6 +663,7 @@ module PhiAttrs
     # @private
     #
     def phi_wrap_extension(method_name)
+      raise NameError, "Undefined methods in `extend_phi_access`: #{method_name}" unless self.respond_to?(method_name)
       return if self.class.__phi_methods_to_extend.include? method_name
 
       wrapped_method = wrapped_extended_name(method_name)

--- a/lib/phi_attrs/phi_record.rb
+++ b/lib/phi_attrs/phi_record.rb
@@ -64,7 +64,7 @@ module PhiAttrs
       end
 
       def validate_extended_methods_exist
-        undefined_methods = self.__phi_extend_methods.reject{|m| self.respond_to?(m)}
+        undefined_methods = self.__phi_extend_methods.reject{|m| self.class.respond_to?(m)}
         raise NameError, "Undefined methods in `extend_phi_access`: #{undefined_methods.join(' ')}" if undefined_methods.any?
       end
 

--- a/lib/phi_attrs/phi_record.rb
+++ b/lib/phi_attrs/phi_record.rb
@@ -663,7 +663,7 @@ module PhiAttrs
     # @private
     #
     def phi_wrap_extension(method_name)
-      raise NameError, "Undefined methods in `extend_phi_access`: #{method_name}" unless self.respond_to?(method_name)
+      raise NameError, "Undefined relationship in `extend_phi_access`: #{method_name}" unless self.respond_to?(method_name)
       return if self.class.__phi_methods_to_extend.include? method_name
 
       wrapped_method = wrapped_extended_name(method_name)

--- a/lib/phi_attrs/phi_record.rb
+++ b/lib/phi_attrs/phi_record.rb
@@ -60,6 +60,12 @@ module PhiAttrs
       #
       def extend_phi_access(*methods)
         self.__phi_extend_methods = methods.map(&:to_s)
+        validate_extended_methods_exist
+      end
+
+      def validate_extended_methods_exist
+        undefined_methods = self.__phi_extend_methods.reject(|m| self.respond_to?(m))
+        raise NameError, "Undefined methods in `extend_phi_access`: #{undefined_methods.join(' ')}" if undefined_methods.any?
       end
 
       # Enable PHI access for any instance of this class.
@@ -624,6 +630,10 @@ module PhiAttrs
     #   # through access logging.
     #
     def phi_wrap_method(method_name)
+      unless self.respond_to?(method_name)
+        PhiAttrs::Logger.warn("#{self.class.name} tried to wrap non-existant method (#{method_name})")
+        return
+      end
       return if self.class.__phi_methods_wrapped.include? method_name
 
       wrapped_method = :"__#{method_name}_phi_wrapped"

--- a/lib/phi_attrs/phi_record.rb
+++ b/lib/phi_attrs/phi_record.rb
@@ -64,7 +64,7 @@ module PhiAttrs
       end
 
       def validate_extended_methods_exist
-        undefined_methods = self.__phi_extend_methods.reject(|m| self.respond_to?(m))
+        undefined_methods = self.__phi_extend_methods.reject{|m| self.respond_to?(m)}
         raise NameError, "Undefined methods in `extend_phi_access`: #{undefined_methods.join(' ')}" if undefined_methods.any?
       end
 

--- a/spec/dummy/app/models/missing_attribute_model.rb
+++ b/spec/dummy/app/models/missing_attribute_model.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+class MissingAttributeModel < ApplicationRecord
+  phi_model
+  phi_include_methods :non_existent_method
+end

--- a/spec/dummy/app/models/missing_extend_model.rb
+++ b/spec/dummy/app/models/missing_extend_model.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+class MissingAttributeModel < ApplicationRecord
+  phi_model
+  phi_include_methods :non_existent_method
+end

--- a/spec/dummy/app/models/missing_extend_model.rb
+++ b/spec/dummy/app/models/missing_extend_model.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class MissingAttributeModel < ApplicationRecord
+class MissingExtendModel < ApplicationRecord
   phi_model
-  phi_include_methods :non_existent_method
+  extend_phi_access :non_existent_model
 end

--- a/spec/dummy/db/migrate/20170214100255_create_patient_infos.rb
+++ b/spec/dummy/db/migrate/20170214100255_create_patient_infos.rb
@@ -24,5 +24,13 @@ class CreatePatientInfos < ActiveRecord::Migration[5.0]
       t.belongs_to :patient_info
       t.string :data
     end
+
+    create_table :missing_attribute_model do |t|
+      t.timestamps
+    end
+
+    create_table :missing_extend_model do |t|
+      t.timestamps
+    end
   end
 end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -23,6 +23,16 @@ ActiveRecord::Schema[7.0].define(version: 2017_02_14_100255) do
     t.index ["patient_info_id"], name: "index_health_records_on_patient_info_id"
   end
 
+  create_table "missing_attribute_model", force: :cascade  do |t|
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
+  end
+
+  create_table "missing_extend_model", force: :cascade  do |t|
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
+  end
+
   create_table "patient_details", force: :cascade do |t|
     t.integer "patient_info_id"
     t.string "detail"

--- a/spec/dummy/factories/missing_attribute_models.rb
+++ b/spec/dummy/factories/missing_attribute_models.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :missing_attribute_model do
+  end
+end

--- a/spec/dummy/factories/missing_extend_models.rb
+++ b/spec/dummy/factories/missing_extend_models.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
 FactoryBot.define do
-  factory :missing_attribute_model do
+  factory :missing_extend_model do
   end
 end

--- a/spec/dummy/factories/missing_extend_models.rb
+++ b/spec/dummy/factories/missing_extend_models.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :missing_attribute_model do
+  end
+end

--- a/spec/phi_attrs/phi_record/phi_wrapping.rb
+++ b/spec/phi_attrs/phi_record/phi_wrapping.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe 'phi_wrapping' do
+  file_name = __FILE__
+
+  let(:missing_attribute_model) { build(:missing_attribute_model) }
+  let(:missing_extend_model) { build(:missing_extend_model) }
+
+  context 'non existant attributes' do
+    it 'wrapping a method' do |t|
+      expect{missing_attribute_model}.not_to raise_error
+    end
+
+    it 'extending a model' do |t|
+      expect{missing_extend_model}.to raise_error(NameError)
+    end
+  end
+end


### PR DESCRIPTION
Safety check when trying to wrap a non existent method and allowing the model to continue to function. This occurs when a table has been migrated and has a new column defined so `attribute_names` says the attibute exists but the `unwrapped_method` doesn't exist in    

```ruby
self.class.send(:alias_method, unwrapped_method, method_name)
```

We are also raising explicit errors for `extend_phi_access` that try to access a non existant model as we want to continue to raise errors as early as possible instead of relying on the wrap_methods