### PR TITLE
72 add uuid tags to all messages for tracing

### DIFF
--- a/lib/phi_attrs.rb
+++ b/lib/phi_attrs.rb
@@ -3,6 +3,7 @@
 require 'rails'
 require 'active_support'
 require 'request_store'
+require 'securerandom'
 
 require 'phi_attrs/version'
 require 'phi_attrs/configure'

--- a/spec/phi_attrs/logger_spec.rb
+++ b/spec/phi_attrs/logger_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe Logger do
       context 'allowed' do
         it 'object_id for unpersisted' do |t|
           PatientInfo.allow_phi!(file_name, t.full_description)
-          expect(PhiAttrs::Logger.logger).to receive(:tagged).with(PhiAttrs::PHI_ACCESS_LOG_TAG, PatientInfo.name, "Object: #{patient_jane.object_id}").and_call_original
+          expect(PhiAttrs::Logger.logger).to receive(:tagged).with(PhiAttrs::PHI_ACCESS_LOG_TAG, PatientInfo.name, "Object: #{patient_jane.object_id}", 'none').and_call_original
           expect(PhiAttrs::Logger.logger).to receive(:info)
           patient_jane.first_name
         end
@@ -77,7 +77,7 @@ RSpec.describe Logger do
           PatientInfo.allow_phi!(file_name, t.full_description)
           patient_jane.save
           expect(patient_jane.persisted?).to be true
-          expect(PhiAttrs::Logger.logger).to receive(:tagged).with(PhiAttrs::PHI_ACCESS_LOG_TAG, PatientInfo.name, "Key: #{patient_jane.id}").and_call_original
+          expect(PhiAttrs::Logger.logger).to receive(:tagged).with(PhiAttrs::PHI_ACCESS_LOG_TAG, PatientInfo.name, "Key: #{patient_jane.id}", 'none').and_call_original
           expect(PhiAttrs::Logger.logger).to receive(:info)
           patient_jane.first_name
         end
@@ -85,7 +85,7 @@ RSpec.describe Logger do
 
       context 'unauthorized' do
         it 'object_id for unpersisted' do
-          expect(PhiAttrs::Logger.logger).to receive(:tagged).with(PhiAttrs::PHI_ACCESS_LOG_TAG, PatientInfo.name, "Object: #{patient_jane.object_id}").and_call_original
+          expect(PhiAttrs::Logger.logger).to receive(:tagged).with(PhiAttrs::PHI_ACCESS_LOG_TAG, PatientInfo.name, "Object: #{patient_jane.object_id}", 'none').and_call_original
           expect(PhiAttrs::Logger.logger).to receive(:tagged).with(PhiAttrs::Exceptions::PhiAccessException::TAG).and_call_original
           expect(PhiAttrs::Logger.logger).to receive(:error)
           expect { patient_jane.first_name }.to raise_error(access_error)
@@ -94,7 +94,7 @@ RSpec.describe Logger do
         it 'id for persisted' do
           patient_jane.save
           # expect(patient_jane.persisted?).to be true
-          expect(PhiAttrs::Logger.logger).to receive(:tagged).with(PhiAttrs::PHI_ACCESS_LOG_TAG, PatientInfo.name, "Key: #{patient_jane.id}").and_call_original
+          expect(PhiAttrs::Logger.logger).to receive(:tagged).with(PhiAttrs::PHI_ACCESS_LOG_TAG, PatientInfo.name, "Key: #{patient_jane.id}", 'none').and_call_original
           expect(PhiAttrs::Logger.logger).to receive(:tagged).with(PhiAttrs::Exceptions::PhiAccessException::TAG).and_call_original
           expect(PhiAttrs::Logger.logger).to receive(:error)
           expect { patient_jane.first_name }.to raise_error(access_error)


### PR DESCRIPTION
Fixes #72 

Adds uuid for tracking the `allow` to the `disallow` so that you can trace the access better.

Full Stack may look similar to:
```
2025-02-12T16:48:57.288185  INFO: [PHI Access Log] [PatientInfo] [Object: 20180] [78d49f3d-f101-43bf-9aea-1cedf9bd0931] PHI Access Enabled for '/app/spec/phi_attrs/phi_record/instance__allow_phi_spec.rb': instance allow_phi nested allowances retains outer access when disallowed at inner level
2025-02-12T16:48:57.288423  INFO: [PHI Access Log] [PatientInfo] [Object: 20180] [78d49f3d-f101-43bf-9aea-1cedf9bd0931] PatientInfo access by ['/app/spec/phi_attrs/phi_record/instance__allow_phi_spec.rb']. Triggered by method: first_name
2025-02-12T16:48:57.288569  INFO: [PHI Access Log] [PatientInfo] [Object: 20180] [900d7182-0653-43a2-b037-09b6a82bd0d9] PHI Access Enabled for '/app/spec/phi_attrs/phi_record/instance__allow_phi_spec.rb': instance allow_phi nested allowances retains outer access when disallowed at inner level
2025-02-12T16:48:57.288722  INFO: [PHI Access Log] [PatientInfo] [Object: 20180] [78d49f3d-f101-43bf-9aea-1cedf9bd0931,900d7182-0653-43a2-b037-09b6a82bd0d9] PatientInfo access by ['/app/spec/phi_attrs/phi_record/instance__allow_phi_spec.rb','/app/spec/phi_attrs/phi_record/instance__allow_phi_spec.rb']. Triggered by method: first_name
2025-02-12T16:48:57.288858  INFO: [PHI Access Log] [PatientInfo] [Object: 20180] [900d7182-0653-43a2-b037-09b6a82bd0d9] PHI access disabled for /app/spec/phi_attrs/phi_record/instance__allow_phi_spec.rb
2025-02-12T16:48:57.289086  INFO: [PHI Access Log] [PatientDetail] [Object: 20200] [2599be66-33dd-4a8b-a4cb-c55079629528] PHI Access Enabled for '/app/spec/phi_attrs/phi_record/instance__allow_phi_spec.rb': instance allow_phi nested allowances retains outer access when disallowed at inner level
2025-02-12T16:48:57.289217  INFO: [PHI Access Log] [PatientDetail] [Object: 20200] [2599be66-33dd-4a8b-a4cb-c55079629528] PatientDetail access by ['/app/spec/phi_attrs/phi_record/instance__allow_phi_spec.rb']. Triggered by method: detail
2025-02-12T16:48:57.289312  INFO: [PHI Access Log] [PatientInfo] [Object: 20180] [78d49f3d-f101-43bf-9aea-1cedf9bd0931] PHI access disabled for /app/spec/phi_attrs/phi_record/instance__allow_phi_spec.rb
2025-02-12T16:48:57.289401  INFO: [PHI Access Log] [PatientDetail] [Object: 20200] [2599be66-33dd-4a8b-a4cb-c55079629528] PHI access disabled for /app/spec/phi_attrs/phi_record/instance__allow_phi_spec.rb

```

When access is not allowed `none` appears:
```
2025-02-12T16:48:57.171578 ERROR: [PHI Access Log] [HealthRecord] [Key: 1] [none] [UNAUTHORIZED ACCESS] Attempted PHI access for HealthRecord 
```
