### PR TITLE
remove call to attributes. may prevent a loop while logging

### DIFF
--- a/lib/phi_attrs/phi_record.rb
+++ b/lib/phi_attrs/phi_record.rb
@@ -553,7 +553,7 @@ module PhiAttrs
     # @return [Array<String>] log key for an instance of this class
     #
     def phi_log_keys
-      @__phi_log_id = persisted? ? "Key: #{attributes[self.class.primary_key]}" : "Object: #{object_id}"
+      @__phi_log_id = persisted? ? "Key: #{public_send(self.class.primary_key)}" : "Object: #{object_id}"
       @__phi_log_keys = [PHI_ACCESS_LOG_TAG, self.class.name, @__phi_log_id]
     end
 


### PR DESCRIPTION
## ChatGPT

The loop is caused by your `phi_wrap_method` calling logging, which calls `tagged`, which calls back into the wrapped method again. The repeating cycle is very clear in the trace.

Here are the repeating segments (the recursive loop):

**Core repeating block:**

```
from phi_attrs/phi_record.rb:637:in `block in phi_wrap_method'
from phi_attrs/phi_record.rb:647:in `block (2 levels) in phi_wrap_method'
from active_support/tagged_logging.rb:138:in `block in tagged'
from active_support/tagged_logging.rb:38:in `tagged'
from active_support/tagged_logging.rb:138:in `tagged'
from phi_attrs/logger.rb:17:in `tagged'
```

This exact 6-line sequence repeats over and over.

**Precursor (entry)**
The whole cycle starts whenever `phi_wrap_method` tries to compute PHI log keys, which itself calls `.attributes`, which triggers logging:

```
from active_record/attribute_methods.rb:346:in `attributes'
from phi_attrs/phi_record.rb:556:in `phi_log_keys'
from phi_attrs/phi_record.rb:637:in `block in phi_wrap_method'
```

Then `.tagged` logging calls back into the wrapped method, producing infinite re-entry.

**Summary**

Your wrapper method logs something *inside* the method it wraps, but the logging itself triggers the wrapped method again (likely because logger metadata accesses model attributes). The fix is to guard your wrapper to avoid invoking logging during attribute access, or extract the logging so it doesn't depend on `attributes`/`to_hash`.

Rails docs for TaggedLogging:
[https://api.rubyonrails.org/classes/ActiveSupport/TaggedLogging.html](https://api.rubyonrails.org/classes/ActiveSupport/TaggedLogging.html)

ActiveModel attribute_set:
[https://api.rubyonrails.org/classes/ActiveModel/AttributeSet.html](https://api.rubyonrails.org/classes/ActiveModel/AttributeSet.html)

ActiveRecord attributes:
[https://api.rubyonrails.org/classes/ActiveRecord/AttributeMethods/ClassMethods.html#method-i-attributes](https://api.rubyonrails.org/classes/ActiveRecord/AttributeMethods/ClassMethods.html#method-i-attributes)
